### PR TITLE
Return records

### DIFF
--- a/component/CreateBox.tsx
+++ b/component/CreateBox.tsx
@@ -7,7 +7,7 @@ import {
 } from "@mui/material";
 import { Dispatch, SetStateAction, useState } from "react";
 import React from "react";
-import { INewRecord } from "./typedef";
+import { ICreatedResponse, ILikingItemClient, INewRecord } from "./typedef";
 import { Favorite, FavoriteBorder } from "@mui/icons-material";
 import NoMealsOutlinedIcon from "@mui/icons-material/NoMealsOutlined";
 import RestaurantOutlinedIcon from "@mui/icons-material/RestaurantOutlined";
@@ -26,7 +26,7 @@ const setRecord = async (record: INewRecord) => {
     `${window.location.href}api/liking`,
     requestInit
   );
-  return response.ok;
+  return response;
 };
 
 const isValidRecord = (record: INewRecord) => {
@@ -35,6 +35,7 @@ const isValidRecord = (record: INewRecord) => {
 };
 
 const ButtonSubmitNew = (prop: {
+  setter: Dispatch<SetStateAction<ILikingItemClient[]>>;
   record: INewRecord;
   reset: () => void;
   disabled: boolean;
@@ -46,8 +47,10 @@ const ButtonSubmitNew = (prop: {
     if (!isValidRecord(record)) {
       prop.showError("エラー: 入力が不十分です");
     } else {
-      const isOK = await setRecord(record);
-      if (isOK) {
+      const response = await setRecord(record);
+      if (response.ok) {
+        const json = (await response.json()) as ICreatedResponse;
+        prop.setter(json.records);
         prop.reset();
       } else {
         prop.showError("エラー: 保存に失敗しました");
@@ -58,7 +61,7 @@ const ButtonSubmitNew = (prop: {
   return (
     <Button
       variant="contained"
-      onClick={(_) => postData(prop.record)}
+      onClick={async (_) => await postData(prop.record)}
       disabled={prop.disabled}
     >
       保存
@@ -119,7 +122,7 @@ const ButtonAddAlias = (prop: {
   );
 };
 export const CreateBox = (prop: {
-  setIsReloadRequired: Dispatch<SetStateAction<boolean>>;
+  setter: Dispatch<SetStateAction<ILikingItemClient[]>>;
   showError: (message: string) => void;
 }) => {
   const [displayName, setDisplayName] = useState("");
@@ -142,7 +145,6 @@ export const CreateBox = (prop: {
     setAlias([] as string[]);
     setIsLike(defaultValues.isLike);
     setIsAllergy(defaultValues.isAllergy);
-    prop.setIsReloadRequired(true);
   };
   return (
     <>
@@ -200,6 +202,7 @@ export const CreateBox = (prop: {
           reset={reset}
           disabled={isButtonDisabled}
           setDisabled={setIsButtonDisabled}
+          setter={prop.setter}
           showError={prop.showError}
         />
       </Stack>

--- a/component/DeleteButton.tsx
+++ b/component/DeleteButton.tsx
@@ -2,10 +2,11 @@ import { IconButton } from "@mui/material";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import React from "react";
 import DeleteSweepOutlinedIcon from "@mui/icons-material/DeleteSweepOutlined";
+import { IDeletedResponse, ILikingItemClient } from "./typedef";
 
 export const DeleteButton = (props: {
   selections: number[];
-  setIsReloadRequired: Dispatch<SetStateAction<boolean>>;
+  setter: Dispatch<SetStateAction<ILikingItemClient[]>>;
 }) => {
   const deleteRecord = async (IDList: number[]) => {
     const requestInit: RequestInit = {
@@ -16,8 +17,12 @@ export const DeleteButton = (props: {
       `${window.location.href}api/liking`,
       requestInit
     );
-    props.setIsReloadRequired(true);
-    return response;
+    if (response.ok) {
+      const json = (await response.json()) as IDeletedResponse;
+      props.setter(json.records);
+    } else {
+      // TODO: Error handling
+    }
   };
   useEffect(() => {
     if (props.selections.length > 0) {
@@ -34,7 +39,7 @@ export const DeleteButton = (props: {
         aria-label="upload picture"
         component="span"
         disabled={isButtonDisabled}
-        onClick={() => deleteRecord(props.selections)}
+        onClick={async () => await deleteRecord(props.selections)}
       >
         <DeleteSweepOutlinedIcon />
       </IconButton>

--- a/component/typedef.ts
+++ b/component/typedef.ts
@@ -1,21 +1,36 @@
-import { Liking, Alias } from '@prisma/client'
-
+import { Liking, Alias } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 export interface IPropsRecords {
-  records: ILikingItemClient[]
+  records: ILikingItemClient[];
 }
 
 export interface ILikingItemServer extends Liking {
-  alias: Alias[]
+  alias: Alias[];
 }
 
 export interface ILikingItemClient extends Liking {
-  alias: string[]
+  alias: string[];
 }
 
 export interface INewRecord {
-  displayName: string
-  isAllergy: boolean
-  isLike: boolean
-  description: string | null
-  alias: string[]
+  displayName: string;
+  isAllergy: boolean;
+  isLike: boolean;
+  description: string | null;
+  alias: string[];
+}
+
+export interface ICreatedResponse {
+  result: Liking;
+  records: ILikingItemClient[];
+}
+
+export interface IReadResponse {
+  result: null;
+  records: ILikingItemClient[];
+}
+
+export interface IDeletedResponse {
+  result: Prisma.BatchPayload[];
+  records: ILikingItemClient[];
 }

--- a/controller/db_access.ts
+++ b/controller/db_access.ts
@@ -54,6 +54,7 @@ export const setRecord = async (record: INewRecord) => {
     const liking = await prisma.liking.create({
       data: newRecord,
     });
+    return liking;
   } catch {
     throw new Error("Transaction error occured.");
   } finally {
@@ -80,6 +81,7 @@ export const deleteRecord = async (likingIDList: number[]) => {
     .flat();
   try {
     const [deletedAlias, deletedLiking] = await prisma.$transaction(queries);
+    return [deletedAlias, deletedLiking];
   } catch {
     throw new Error("Transaction error occured.");
   } finally {

--- a/pages/App.tsx
+++ b/pages/App.tsx
@@ -8,8 +8,11 @@ import CloseIcon from "@mui/icons-material/Close";
 
 const getList = async () => {
   const response = await fetch(`${window.location.href}api/liking`);
-  const itemList = (await response.json()) as ILikingItemClient[];
-  return itemList;
+  const itemList = (await response.json()) as {
+    result: null;
+    records: ILikingItemClient[];
+  };
+  return itemList.records;
 };
 const initialValue = [] as ILikingItemClient[];
 export const RecordsContext = createContext(initialValue);

--- a/pages/App.tsx
+++ b/pages/App.tsx
@@ -2,24 +2,25 @@ import { useState, useEffect, createContext } from "react";
 import { SearchBox } from "../component/SearchBox";
 import { CreateBox } from "../component/CreateBox";
 import { DeleteButton } from "../component/DeleteButton";
-import { ILikingItemClient } from "../component/typedef";
+import { ILikingItemClient, IReadResponse } from "../component/typedef";
 import { Box, Snackbar, IconButton } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 
 const getList = async () => {
   const response = await fetch(`${window.location.href}api/liking`);
-  const itemList = (await response.json()) as {
-    result: null;
-    records: ILikingItemClient[];
-  };
-  return itemList.records;
+  if (response.ok) {
+    const json = (await response.json()) as IReadResponse;
+    return json.records;
+  } else {
+    throw new Error("Cannot fetch items");
+    // TODO: Error handling
+  }
 };
 const initialValue = [] as ILikingItemClient[];
 export const RecordsContext = createContext(initialValue);
 
 export default function App() {
   const [records, setRecords] = useState(initialValue);
-  const [isReloadRequired, setIsReloadRequired] = useState(true);
   const [selections, setSelections] = useState([] as number[]);
   const [isSnackOpen, setIsSnakOpen] = useState(false);
   const [snackMessage, setSnackMessage] = useState("");
@@ -35,28 +36,18 @@ export default function App() {
     </>
   );
   useEffect(() => {
-    if (!isReloadRequired) {
-      return;
-    }
     const initialize = async () => {
       const _dbRecords = await getList();
       setRecords(_dbRecords);
     };
     initialize();
-    setIsReloadRequired(false);
-  }, [isReloadRequired]);
+  }, []);
 
   return (
     <RecordsContext.Provider value={records}>
       <Box m={2} pt={3}>
-        <CreateBox
-          setIsReloadRequired={setIsReloadRequired}
-          showError={showError}
-        />
-        <DeleteButton
-          selections={selections}
-          setIsReloadRequired={setIsReloadRequired}
-        />
+        <CreateBox setter={setRecords} showError={showError} />
+        <DeleteButton selections={selections} setter={setRecords} />
         <SearchBox setSelections={setSelections} />
       </Box>
       <Snackbar

--- a/pages/api/liking.ts
+++ b/pages/api/liking.ts
@@ -4,7 +4,13 @@ import {
   setRecord,
   deleteRecord,
 } from "../../controller/db_access";
-import { ILikingItemClient, INewRecord } from "../../component/typedef";
+import {
+  ILikingItemClient,
+  INewRecord,
+  ICreatedResponse,
+  IDeletedResponse,
+  IReadResponse,
+} from "../../component/typedef";
 import { Liking, Prisma } from "@prisma/client";
 
 const isNewRecord = (arg: unknown): arg is INewRecord => {
@@ -34,11 +40,7 @@ const isIDList = (arg: unknown): arg is number[] => {
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    | {
-        result: Liking | null | Prisma.BatchPayload[];
-        records: ILikingItemClient[];
-      }
-    | { message: string }
+    IReadResponse | ICreatedResponse | IDeletedResponse | { message: string }
   >
 ) {
   try {


### PR DESCRIPTION
レコードの作成・削除の際に、レスポンスの一部として最新のレコードを返す。
これにより、変更後のレコードを取得するために別途クライアントからリクエストを発行せずに済む。

`insert`, `delete`と同一トランザクション内で`select`を実行してもいいが、Prismaを利用する部分(`handler`)の型が若干複雑化してきたため保留。

レコードが増えた際にレスポンスが重くなるので、ページャの実装などの検討が別途必要になりそう。
