### PR TITLE
モバイル表示の改善

### DIFF
--- a/component/CreateBox.tsx
+++ b/component/CreateBox.tsx
@@ -4,6 +4,7 @@ import {
   FormControlLabel,
   Stack,
   TextField,
+  Box,
 } from "@mui/material";
 import { Dispatch, SetStateAction, useState } from "react";
 import React from "react";
@@ -163,30 +164,34 @@ export const CreateBox = (prop: {
           value={description}
           setter={setDescription}
         />
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={isLike}
-              onChange={(e) => setIsLike(e.target.checked)}
-              icon={<FavoriteBorder />}
-              checkedIcon={<Favorite />}
-            />
-          }
-          label="好み"
-          labelPlacement="end"
-        />
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={isAllergy}
-              onChange={(e) => setIsAllergy(e.target.checked)}
-              icon={<RestaurantOutlinedIcon />}
-              checkedIcon={<NoMealsOutlinedIcon />}
-            />
-          }
-          label="アレルギー"
-          labelPlacement="end"
-        />
+        <Box style={{ width: "auto" }} maxWidth="sm">
+          <FormControlLabel
+            style={{ height: "100%", padding: "0 0.5em 0 0.5em" }}
+            control={
+              <Checkbox
+                checked={isLike}
+                onChange={(e) => setIsLike(e.target.checked)}
+                icon={<FavoriteBorder />}
+                checkedIcon={<Favorite />}
+              />
+            }
+            label="好み"
+            labelPlacement="end"
+          />
+          <FormControlLabel
+            style={{ height: "100%", padding: "0 0.5em 0 0.5em" }}
+            control={
+              <Checkbox
+                checked={isAllergy}
+                onChange={(e) => setIsAllergy(e.target.checked)}
+                icon={<RestaurantOutlinedIcon />}
+                checkedIcon={<NoMealsOutlinedIcon />}
+              />
+            }
+            label="アレルギー"
+            labelPlacement="end"
+          />
+        </Box>
         <ButtonAddAlias value={aliasList} setter={setAlias} />
         {aliasList.map((alias, index) => (
           <StoredAliasField

--- a/component/Record.tsx
+++ b/component/Record.tsx
@@ -1,6 +1,9 @@
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import { Dispatch, SetStateAction } from "react";
 import { IPropsRecords } from "./typedef";
+import { Favorite, FavoriteBorder } from "@mui/icons-material";
+import NoMealsOutlinedIcon from "@mui/icons-material/NoMealsOutlined";
+import RestaurantOutlinedIcon from "@mui/icons-material/RestaurantOutlined";
 
 export default function Records(
   props: IPropsRecords & { setSelections: Dispatch<SetStateAction<number[]>> }
@@ -47,7 +50,7 @@ const headers: GridColDef[] = [
     type: "boolean",
     editable: false,
     renderCell: (arg) => {
-      return <>{arg.value ? "好き" : "好きじゃない"}</>;
+      return <>{arg.value ? <Favorite /> : <FavoriteBorder />}</>;
     },
     flex: 20,
   },
@@ -58,7 +61,9 @@ const headers: GridColDef[] = [
     type: "boolean",
     editable: false,
     renderCell: (arg) => {
-      return <>{arg.value ? "アレルギー" : "アレルギーじゃない"}</>;
+      return (
+        <>{arg.value ? <NoMealsOutlinedIcon /> : <RestaurantOutlinedIcon />}</>
+      );
     },
     flex: 20,
   },

--- a/component/Record.tsx
+++ b/component/Record.tsx
@@ -33,12 +33,6 @@ export default function Records(
 
 const headers: GridColDef[] = [
   {
-    field: "id",
-    headerName: "ID",
-    editable: false,
-    flex: 5,
-  },
-  {
     field: "displayName",
     headerName: "name",
     editable: false,

--- a/pages/App.tsx
+++ b/pages/App.tsx
@@ -5,6 +5,7 @@ import { DeleteButton } from "../component/DeleteButton";
 import { ILikingItemClient, IReadResponse } from "../component/typedef";
 import { Box, Snackbar, IconButton } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 const getList = async () => {
   const response = await fetch(`${window.location.href}api/liking`);
@@ -24,6 +25,7 @@ export default function App() {
   const [selections, setSelections] = useState([] as number[]);
   const [isSnackOpen, setIsSnakOpen] = useState(false);
   const [snackMessage, setSnackMessage] = useState("");
+  const isWide = useMediaQuery("(min-width:600px)");
   const showError = (message: string) => {
     setSnackMessage(message);
     setIsSnakOpen(true);
@@ -45,7 +47,7 @@ export default function App() {
 
   return (
     <RecordsContext.Provider value={records}>
-      <Box m={2} pt={3}>
+      <Box m={isWide ? 2 : 0} pt={isWide ? 3 : 0}>
         <CreateBox setter={setRecords} showError={showError} />
         <DeleteButton selections={selections} setter={setRecords} />
         <SearchBox setSelections={setSelections} />


### PR DESCRIPTION
スマホなどの狭い画面での操作を改善
- 好み/アレルギーのボタンを横並びに表示
- 好み/アレルギーの列をアイコンで表示
- id列の削除
- 余白の調整
